### PR TITLE
Support vim compiled with +python3 (e.g. Ubuntu 17.04)

### DIFF
--- a/plugin/load_breakpoints.py
+++ b/plugin/load_breakpoints.py
@@ -14,8 +14,11 @@ Example usage:
 
 import sys
 
-from pudb.settings import load_breakpoints
-from pudb import NUM_VERSION
+try:
+    from pudb.settings import load_breakpoints
+    from pudb import NUM_VERSION
+except ImportError:
+    exit(-1)
 
 args = () if NUM_VERSION >= (2013, 1) else (None,)
 bps = load_breakpoints(*args)

--- a/plugin/load_breakpoints.py
+++ b/plugin/load_breakpoints.py
@@ -1,0 +1,28 @@
+""" 
+Usage: load_breakpoints.py <filename>
+
+Print breakpoints in <filename>
+
+Example usage:
+
+    $ ./load_breakpoints.py foo.py
+    3
+    50
+    57
+
+"""
+
+import sys
+
+from pudb.settings import load_breakpoints
+from pudb import NUM_VERSION
+
+args = () if NUM_VERSION >= (2013, 1) else (None,)
+bps = load_breakpoints(*args)
+
+filename = sys.argv[1]
+
+bps = [bp[1] for bp in bps if bp[0] == filename]
+
+for bp in bps:
+    print(bp)

--- a/plugin/pudb.vim
+++ b/plugin/pudb.vim
@@ -70,6 +70,7 @@ row, col = vim.current.window.cursor
 
 scriptname = os.path.join(vim.eval('s:plugin_dir'), 'set_breakpoint.py')
 proc = subprocess.Popen(['python', scriptname, filename, str(row)])
+proc.wait()
 
 vim.command('call s:UpdateBreakPoints()')
 EOF

--- a/plugin/pudb.vim
+++ b/plugin/pudb.vim
@@ -44,11 +44,13 @@ python3 << EOF
 import vim
 import os
 import subprocess
+import shutil
 
 filename = vim.eval('expand("%:p")')
 
 scriptname = os.path.join(vim.eval('s:plugin_dir'), 'load_breakpoints.py')
-bps = subprocess.Popen(['python', scriptname, filename], stdout=subprocess.PIPE)
+python_path = shutil.which('python') or shutil.which('python3')
+bps = subprocess.Popen([python_path, scriptname, filename], stdout=subprocess.PIPE)
 
 for bp in bps.stdout:
     bp = int(bp.strip())
@@ -69,7 +71,8 @@ filename = vim.eval('expand("%:p")')
 row, col = vim.current.window.cursor
 
 scriptname = os.path.join(vim.eval('s:plugin_dir'), 'set_breakpoint.py')
-proc = subprocess.Popen(['python', scriptname, filename, str(row)])
+python_path = shutil.which('python') or shutil.which('python3')
+proc = subprocess.Popen([python_path, scriptname, filename, str(row)])
 proc.wait()
 
 vim.command('call s:UpdateBreakPoints()')

--- a/plugin/pudb.vim
+++ b/plugin/pudb.vim
@@ -9,8 +9,8 @@ if exists('g:loaded_pudb_plugin') || &cp
 endif
 let g:loaded_pudb_plugin = 1
 
-if !has("python")
-    echo "Error: Required vim compiled with +python"
+if !has("python3")
+    echo "Error: Required vim compiled with +python3"
     finish
 endif
 
@@ -40,7 +40,7 @@ endfor
 let b:pudb_sign_ids = []
 
 
-python << EOF
+python3 << EOF
 import vim
 import os
 import subprocess
@@ -62,13 +62,13 @@ EOF
 endfunction
 
 function! s:ToggleBreakPoint()
-python << EOF
+python3 << EOF
 import vim
 
 filename = vim.eval('expand("%:p")')
 row, col = vim.current.window.cursor
 
-scriptname = os.path.join(vim.eval('s:plugin_dir'), 'save_breakpoints.py')
+scriptname = os.path.join(vim.eval('s:plugin_dir'), 'set_breakpoint.py')
 proc = subprocess.Popen(['python', scriptname, filename, str(row)])
 
 vim.command('call s:UpdateBreakPoints()')

--- a/plugin/set_breakpoint.py
+++ b/plugin/set_breakpoint.py
@@ -1,0 +1,41 @@
+""" 
+Usage: set_breakpoint.py <filename> <lineno>
+
+Set a breakpoint in <filename> at <lineno>
+
+Example usage:
+
+    $ ./load_breakpoints.py foo.py
+    12
+    $ ./set_breakpoint.py foo.py 11
+    $ ./load_breakpoints.py foo.py
+    12
+    11
+"""
+
+import sys
+
+from pudb.settings import load_breakpoints, save_breakpoints
+from pudb import NUM_VERSION
+
+args = () if NUM_VERSION >= (2013, 1) else (None,)
+bps = [bp[:2] for bp in load_breakpoints(*args)]
+
+filename = sys.argv[1]
+row = int(sys.argv[2])
+
+bp = (filename, row)
+if bp in bps:
+    bps.pop(bps.index(bp))
+else:
+    bps.append(bp)
+
+class BP(object):
+    def __init__(self, fn, ln):
+        self.file = fn
+        self.line = ln
+        self.cond = None
+
+bp_list = [BP(bp[0], bp[1]) for bp in bps]
+
+save_breakpoints(bp_list)


### PR DESCRIPTION
Ubuntu 17.04 dropped all vim packages that are compiled with python2. This pull request adds support for vim compiled only with +python3, in a way that also allows setting breakpoints in python2 projects.

pudb uses different breakpoint files for different python versions. As currently implemented, the vim-pudb will set breakpoint for the python version that is installed when running `python`, so if `python` runs `python2.7`, vim-pudb will set breakpoint for pudb when running on python 2.7, but if `python` runs `python3.5` from virtualenv, vim-pudb will set breakpoint for pudb when running on python 3.5. 

Future improvements may be to have a setting to allow adding breakpoints to multiple versions at the same time (e.g. `let g:pudb_python_versions=['python2.7', 'python3.5', '/home/me/virtualenv/pypy2.7']`).