### PR TITLE
Add support for neovim, newest pudb and atomize python code

### DIFF
--- a/plugin/pudb.vim
+++ b/plugin/pudb.vim
@@ -1,16 +1,19 @@
 " File: pudb.vim
 " Author: Christophe Simonis
-" Description: Manage pudb breakpoints directly into vim
-" Last Modified: December 03, 2012
-"
+" Description: Manage pudb breakpoints directly into (neo)vim
+" Last Modified: 2017-09-12
 
 if exists('g:loaded_pudb_plugin') || &cp
     finish
 endif
-let g:loaded_pudb_plugin = 1
 
-if !has("python")
-    echo "Error: Required vim compiled with +python"
+let g:loaded_pudb_plugin = 1
+let g:plugin_path = expand('<sfile>:p:h')
+let s:toggle_path = g:plugin_path . '/toggle.py'
+let s:update_path = g:plugin_path . '/update.py'
+
+if !has("python") && !has("python3")
+    echo "Error: Required (neo)vim compiled with +python"
     finish
 endif
 
@@ -26,68 +29,19 @@ augroup end
 command! TogglePudbBreakPoint call s:ToggleBreakPoint()
 
 function! s:UpdateBreakPoints()
+    " first remove existing signs
+    if !exists("b:pudb_sign_ids")
+        let b:pudb_sign_ids = []
+    endif
 
-" first remove existing signs
-if !exists("b:pudb_sign_ids")
+    for i in b:pudb_sign_ids
+        exec "sign unplace " . i
+    endfor
+
     let b:pudb_sign_ids = []
-endif
-
-for i in b:pudb_sign_ids
-    exec "sign unplace " . i
-endfor
-let b:pudb_sign_ids = []
-
-
-python << EOF
-import vim
-from pudb.settings import load_breakpoints
-from pudb import NUM_VERSION
-
-filename = vim.eval('expand("%:p")')
-
-args = () if NUM_VERSION >= (2013, 1) else (None,)
-bps = load_breakpoints(*args)
-
-for bp in bps:
-    if bp[0] != filename:
-        continue
-
-    sign_id = vim.eval("s:next_sign_id")
-    vim.command("sign place %s line=%s name=PudbBreakPoint file=%s" % (sign_id, bp[1], filename))
-    vim.eval("add(b:pudb_sign_ids, s:next_sign_id)")
-    vim.command("let s:next_sign_id += 1")
-EOF
-
+    execute 'pyfile ' . s:update_path
 endfunction
 
 function! s:ToggleBreakPoint()
-python << EOF
-import vim
-from pudb.settings import load_breakpoints, save_breakpoints
-from pudb import NUM_VERSION
-
-args = () if NUM_VERSION >= (2013, 1) else (None,)
-bps = [bp[:2] for bp in load_breakpoints(*args)]
-
-filename = vim.eval('expand("%:p")')
-row, col = vim.current.window.cursor
-
-bp = (filename, row)
-if bp in bps:
-    bps.pop(bps.index(bp))
-else:
-    bps.append(bp)
-
-class BP(object):
-    def __init__(self, fn, ln):
-        self.file = fn
-        self.line = ln
-
-bp_list = [BP(bp[0], bp[1]) for bp in bps]
-
-save_breakpoints(bp_list)
-
-vim.command('call s:UpdateBreakPoints()')
-EOF
+    execute 'pyfile ' . s:toggle_path
 endfunction
-

--- a/plugin/pudb.vim
+++ b/plugin/pudb.vim
@@ -1,7 +1,7 @@
 " File: pudb.vim
 " Author: Christophe Simonis
 " Description: Manage pudb breakpoints directly into (neo)vim
-" Last Modified: 2017-09-12
+" Last Modified: 2017-09-13
 
 if exists('g:loaded_pudb_plugin') || &cp
     finish

--- a/plugin/toggle.py
+++ b/plugin/toggle.py
@@ -26,6 +26,9 @@ class BP(object):
     def __init__(self, fn, ln):
         self.file = fn
         self.line = ln
+        # TODO: Properly handle conditions and allow the user to create them
+        # from (neo)vim
+        self.cond = None
 
 
 bp_list = [BP(_bp[0], _bp[1]) for _bp in bps]

--- a/plugin/toggle.py
+++ b/plugin/toggle.py
@@ -1,0 +1,35 @@
+try:
+    import neovim
+    import os
+    sock = os.environ.get('NVIM_LISTEN_ADDRESS')
+    vim = neovim.attach('socket', sock)
+except:
+    import vim
+
+from pudb.settings import load_breakpoints, save_breakpoints
+from pudb import NUM_VERSION
+
+args = () if NUM_VERSION >= (2013, 1) else (None,)
+bps = [bp[:2] for bp in load_breakpoints(*args)]
+
+filename = vim.eval('expand("%:p")')
+row, col = vim.current.window.cursor
+
+bp = (filename, row)
+if bp in bps:
+    bps.pop(bps.index(bp))
+else:
+    bps.append(bp)
+
+
+class BP(object):
+    def __init__(self, fn, ln):
+        self.file = fn
+        self.line = ln
+
+
+bp_list = [BP(_bp[0], _bp[1]) for _bp in bps]
+
+save_breakpoints(bp_list)
+
+vim.command('call s:UpdateBreakPoints()')

--- a/plugin/update.py
+++ b/plugin/update.py
@@ -1,0 +1,25 @@
+try:
+    import neovim
+    import os
+    sock = os.environ.get('NVIM_LISTEN_ADDRESS')
+    vim = neovim.attach('socket', sock)
+except:
+    import vim
+
+from pudb.settings import load_breakpoints
+from pudb import NUM_VERSION
+
+filename = vim.eval('expand("%:p")')
+
+args = () if NUM_VERSION >= (2013, 1) else (None,)
+bps = load_breakpoints(*args)
+
+for bp in bps:
+    if bp[0] != filename:
+        continue
+
+    sign_id = vim.eval("s:next_sign_id")
+    vim.command("sign place %s line=%s name=PudbBreakPoint file=%s"
+                % (sign_id, bp[1], filename))
+    vim.eval("add(b:pudb_sign_ids, s:next_sign_id)")
+    vim.command("let s:next_sign_id += 1")


### PR DESCRIPTION
Neovim v0.2.0 support added (tested), shouldn't break vim support (not tested)

Newest pudb requires that bp objects contain a `cond` attribute, if they don't the program breaks and you get a traceback, solution for now is to assign None to self.cond during BP init, which works but is not ideal if anyone wants to actually add a BP condition.

Python code is now within their own files for easier modification/readability.

Not mentioned in any of the commits but I added a check to see if (neo)vim was compiled with python3, so that if it was compiled with it, it wouldn't break because it didn't have +python but +python3, since the python code should be py2 and py3 compatible